### PR TITLE
fix typo

### DIFF
--- a/lection-16.tex
+++ b/lection-16.tex
@@ -442,7 +442,7 @@ $\lambda f.\lambda x.f\ (f\ x) : (\beta\rightarrow\beta)\rightarrow(\beta\righta
 \begin{dfn}Комбинатор --- лямбда-терм без свободных переменных
 \end{dfn}
 \begin{dfn}[исходная идея Моисея Шейнфинкеля, 1924]$S := \lambda x.\lambda y.\lambda z.x\ z\ (y\ z)$, $K := \lambda x.\lambda y.x$, $I := \lambda x.x$\\
-(verSchmelzung, Konstanz --- исходно <<C>> у Шейнфинкеля, Identit\"at)
+(Verschmelzung, Konstanz --- исходно <<C>> у Шейнфинкеля, Identit\"at)
 \end{dfn}
 
 \begin{thm}Пусть $N$ --- некоторый замкнутый лямбда-терм. Тогда найдётся выражение $M$, состоящее из комбинаторов $S$,$K$, 


### PR DESCRIPTION
Заглавная буква внутри слова допустима только в особых случаях, например:
- в сложных словах при сохранении собственного имени,
- в некоторых устаревших или рекламных написаниях,
- в стиле CamelCase (но это не норма немецкой орфографии).

Это обычное немецкое существительное (Verschmelzung — «слияние»).
По нормам немецкой орфографии оно пишется с заглавной первой буквы (как все существительные).