### PR TITLE
fix typo

### DIFF
--- a/lection-02.tex
+++ b/lection-02.tex
@@ -577,7 +577,7 @@ $$a_1^b = \left({\sqrt{2}^{\sqrt{2}}}\right)^{\sqrt{2}} = \sqrt{2}^2 = 2$$
 %\begin{center}
 %\includegraphics[width=3cm]{brower}
 %
-%Лёйтзен Брауер\end{center}
+%Лёйтзен Брауэр\end{center}
 
 %Критика доказательств чистого существования
 \end{frame}


### PR DESCRIPTION
Правильное написание полного имени учёного: Лёйтзен Эгберт Ян Брауэр (нидерл. Luitzen Egbertus Jan Brouwer).
По правилам нидерландско-русской практической транскрипции "ouwe" передаётся как "ауэ"(https://ru.wikipedia.org/wiki/Нидерландско-русская_практическая_транскрипция).