### PR TITLE
fix

### DIFF
--- a/lection-01.tex
+++ b/lection-01.tex
@@ -85,7 +85,7 @@ $$X \in X$$ \pause
 \begin{frame}{Программа Гильберта}
 \begin{itemize}
 \item Программа Гильберта: полностью формализовать математику, доказать непротиворечивость:
-Neubegründung der Mathematik: Erste Mitteilung”, Abhandlungen aus dem Seminar der Hamburgischen Universität, 1: 157–177. Series of talks given at the University of Hamburg, July 25–27, 1921
+”Neubegründung der Mathematik: Erste Mitteilung”, Abhandlungen aus dem Seminar der Hamburgischen Universität, 1: 157–177. Series of talks given at the University of Hamburg, July 25–27, 1921
 
 \begin{itemize}
 \item формализация всей математики;


### PR DESCRIPTION
У названия статьи стоит только закрывающая кавычка: Neubegründung der Mathematik: Erste Mitteilung”. По нормам русского языка кавычка — это парный знак. 

https://orfogrammka.ru/%D1%82%D0%B8%D0%BF%D0%BE%D0%B3%D1%80%D0%B0%D1%84%D0%B8%D0%BA%D0%B0/%D0%BF%D0%B0%D1%80%D0%BD%D1%8B%D0%B5_%D0%B8_%D0%BD%D0%B5%D0%BF%D0%B0%D1%80%D0%BD%D1%8B%D0%B5_%D0%BA%D0%B0%D0%B2%D1%8B%D1%87%D0%BA%D0%B8/

Туров Алексей