### PR TITLE
fix

### DIFF
--- a/lection-04.tex
+++ b/lection-04.tex
@@ -104,7 +104,7 @@
 \draw[->] (A) to (C); 
 }\end{center}
 
-Тогда, $W_3 \Vdash \neg A$, но $W_1 \not\Vdash A$ (по определению) и $W_1 \not\Vdash \neg A$ (так как
+Тогда $W_3 \Vdash \neg A$, но $W_1 \not\Vdash A$ (по определению) и $W_1 \not\Vdash \neg A$ (так как
 $W_1 \preceq W_2$ и $W_2 \Vdash A$). Значит, $W_1 \not\Vdash A \vee \neg A$.
 \end{exmprus}
 \end{frame}


### PR DESCRIPTION
"Тогда" не является вводным словом, а выступает как наречное слово со значением примерно «в таком случае / в тот момент». (https://gramota.ru/poisk?mode=all&query=%D0%A2%D0%BE%D0%B3%D0%B4%D0%B0)

Вводные слова выделяются запятыми, потому что они не являются членами предложения и выражают отношение говорящего к сообщению. Напротив, если слово является обстоятельством в начале предложения, запятая после него не ставится. (https://gramota.ru/uchebnik/pravila/normy-postanovki-znakov-prepinaniya-v-predlozheniyakh-s-vvodnymi-slovami)


Туров Алексей