### PR TITLE
Fix typo

### DIFF
--- a/lection-15.tex
+++ b/lection-15.tex
@@ -103,7 +103,7 @@
 $$\beta := \forall x_1.\exists x_2.\forall x_3.\exists x_4\dots \forall x_{n-1}.\exists x_n.\varphi$$
 
 \item Исходная задача: проверка $\vdash\alpha$. Это эквивалентно $\vdash\beta$. Эквивалентно $\models\beta$.
-То есть, при любом $D$:
+То есть при любом $D$:
 \begin{itemize}
 \item при любом $x_1$ найдётся такой $x_2$, что ...
 \item при любом $x_3$ найдётся $x_4$, что ... (и т.д.) ...


### PR DESCRIPTION
Союз "то есть" не является вводным словом, поэтому обособлять его запятой не нужно.

- https://gramota.ru/biblioteka/spravochniki/spravochnik-po-punktuatsii/to-est

Кравцов Вадим М3233